### PR TITLE
ci: .github/workflows/deploy.yml preview job sets gh environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - test
     runs-on: ubuntu-latest
     environment:
-      name: ${{ (github.ref_name != 'main') && format('preview-{0}', github.ref_name) || "staging" }}
+      name: ${{ (github.ref_name == 'main') && 'staging' || format('preview-{0}', github.ref_name) }}
       url: ${{ steps.cloudflare_url.outputs.stdout }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - test
     runs-on: ubuntu-latest
     environment:
-      name: ${{ steps.environment_name.outputs.stdout }}
+      name: "${{ format('preview-{0}', github.ref_name) }}"
       url: ${{ steps.cloudflare_url.outputs.stdout }}
     steps:
       - id: environment_name

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,12 +15,9 @@ jobs:
       - test
     runs-on: ubuntu-latest
     environment:
-      name: "${{ format('preview-{0}', github.ref_name) }}"
+      name: ${{ (github.ref_name != "main") && format('preview-{0}', github.ref_name) || "staging" }}
       url: ${{ steps.cloudflare_url.outputs.stdout }}
     steps:
-      - id: environment_name
-        run: echo "preview-$GITHUB_REF_NAME"
-
       - uses: actions/checkout@v3
       - uses: ./.github/actions/pnpm
       - run: pnpm pages:build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - test
     runs-on: ubuntu-latest
     environment:
-      name: ${{ (github.ref_name != "main") && format('preview-{0}', github.ref_name) || "staging" }}
+      name: ${{ (github.ref_name != main) && format('preview-{0}', github.ref_name) || "staging" }}
       url: ${{ steps.cloudflare_url.outputs.stdout }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: ${{ (github.ref_name == 'main') && 'staging' || format('preview-{0}', github.ref_name) }}
-      url: ${{ steps.cloudflare_url.outputs.stdout }}
+      url: ${{ (github.ref_name == 'main') && 'https://staging.console.web3.storage/' || steps.cloudflare_url.outputs.stdout }}
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/pnpm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - test
     runs-on: ubuntu-latest
     environment:
-      name: ${{ (github.ref_name != main) && format('preview-{0}', github.ref_name) || "staging" }}
+      name: ${{ (github.ref_name != 'main') && format('preview-{0}', github.ref_name) || "staging" }}
       url: ${{ steps.cloudflare_url.outputs.stdout }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,9 @@ jobs:
     needs:
       - test
     runs-on: ubuntu-latest
+    environment:
+      name: preview-${{GITHUB_REF_NAME}}
+      url: ${{ steps.cloudflare_url.outputs.stdout }}
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/pnpm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - test
     runs-on: ubuntu-latest
     environment:
-      name: preview-${{GITHUB_REF_NAME}}
+      name: preview-$GITHUB_REF_NAME
       url: ${{ steps.cloudflare_url.outputs.stdout }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,9 +15,12 @@ jobs:
       - test
     runs-on: ubuntu-latest
     environment:
-      name: preview-$GITHUB_REF_NAME
+      name: ${{ steps.environment_name.outputs.stdout }}
       url: ${{ steps.cloudflare_url.outputs.stdout }}
     steps:
+      - id: environment_name
+        run: echo "preview-$GITHUB_REF_NAME"
+
       - uses: actions/checkout@v3
       - uses: ./.github/actions/pnpm
       - run: pnpm pages:build


### PR DESCRIPTION
Motivation
* https://github.com/web3-storage/console/issues/17
  * make preview environments easier to find by having our github workflow files use the `environment` affordance to record when it deploys preview/staging environments to cloudflare pages. That way they will be browsable/clickable in the GitHub UI at https://github.com/web3-storage/console/deployments

note
* [x] wait for cloudflare to not be down to ensure the CI workflow will then pass https://github.com/web3-storage/console/pull/20
