### PR TITLE
ci: .github/workflows/deploy.yml release job does not wait on preview

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,7 +95,6 @@ jobs:
       url: https://w3up.web3.storage
     needs:
       - test
-      - preview
       - changelog
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Motivation:
* I'm sitting looking at this workflow waiting for release after merging a release-please pr and I don't need/want to have to wait for `preview` here https://github.com/web3-storage/console/actions/runs/6778644273 . This was already deployed to a preview environment went it hit `main` branch the first time, which triggered the release-please PR, and now this is the second run on `main` so I don't wanna have to wait for a second `preview` job