### PR TITLE
docs: update ToS reference

### DIFF
--- a/src/components/Authenticator.tsx
+++ b/src/components/Authenticator.tsx
@@ -29,8 +29,8 @@ export function AuthenticationForm (): JSX.Element {
           </button>
         </div>
       </AuthCore.Form>
-      <p className='text-xs text-white/80 italic max-w-xs text-left mt-6'>
-        By registering with {serviceName} web3.storage, you agree to the web3.storage <a className='underline' href='https://web3.storage/terms/'>Terms of Service</a>.
+      <p className='text-xs text-white/80 italic max-w-xs text-center mt-6'>
+        By registering with web3.storage, you agree to the web3.storage <a className='underline' href='https://web3.storage/terms/'>Terms of Service</a>.
       </p>
     </div >
   )


### PR DESCRIPTION
Original change didn't remove a variable and resultant text needed to be centred. 