### PR TITLE
feat: let users use the console without an account

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,7 +11,7 @@
 }
 
 .authenticator {
-  @apply bg-zinc-950 w-full h-screen flex flex-col justify-center items-center;
+  @apply flex flex-col items-start;
 }
 
 @keyframes bgPosDrift {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,19 +9,22 @@ import { H2 } from '@/components/Text'
 export default function SpacePage (): JSX.Element {
   const [{ spaces }] = useKeyring()
 
-  if (spaces.length === 0) {
-    return <div></div>
-  }
-
   return (
     <>
       <SpacesNav />
-      <div>
-        <H2>Pick a Space</H2>
-        <div className='max-w-lg border rounded-md border-zinc-700'>
-          { spaces.map(s => <Item space={s} key={s.did()} /> ) }
+      {spaces && (spaces.length > 0) ? (
+        <div>
+          <H2>Pick a Space</H2>
+          <div className='max-w-lg border rounded-md border-zinc-700'>
+            {spaces.map(s => <Item space={s} key={s.did()} />)}
+          </div>
         </div>
-      </div>
+      ) : (
+        <div>
+          <H2>You have no spaces</H2>
+          <p>To start uploading, import or create a space by clicking on the tabs above.</p>
+        </div>
+      )}
     </>
   )
 }

--- a/src/app/space/create/page.tsx
+++ b/src/app/space/create/page.tsx
@@ -3,33 +3,39 @@
 import { SpaceCreatorForm } from '@/components/SpaceCreator'
 import { SpacesNav } from '../layout'
 import { H2 } from '@/components/Text'
+import { AuthenticationEnsurer } from '@/components/Authenticator'
+import { MaybePlanGate } from '@/components/PlanGate'
 
 export default function CreateSpacePage (): JSX.Element {
   return (
     <>
       <SpacesNav />
-      <div className='max-w-xl'>
-        <H2>Create a new Space</H2>
-        <SpaceCreatorForm />
-      </div>
-      <div className='mt-12 max-w-xl text-sm leading-6'>
-        <H2>Explain</H2>
-        <p>
-          A space is decentralised bucket. The name you give it is a memorable alias.
-        </p>
-        <p>
-          It&apos;s true name is a unique DID derived from a key-pair.
-        </p>
-        <p className="mt-4">
-          Console, your agent, creates a UCAN delegating all capabilities on that space to your email DID.
-        </p>
-        <p className="mt-4">
-          You can allow others to use your space, by creating a delegation to their email or a specific agent from the share page.
-        </p>
-        <p className="mt-4">
-          For details on how this works see <a className='underline' href="https://github.com/web3-storage/specs/blob/main/w3-account.md">specs/w3-account</a>
-        </p>
-      </div>
+      <AuthenticationEnsurer>
+        <MaybePlanGate>
+          <div className='max-w-xl'>
+            <H2>Create a new Space</H2>
+            <SpaceCreatorForm />
+          </div>
+          <div className='mt-12 max-w-xl text-sm leading-6'>
+            <H2>Explain</H2>
+            <p>
+              A space is decentralised bucket. The name you give it is a memorable alias.
+            </p>
+            <p>
+              It&apos;s true name is a unique DID derived from a key-pair.
+            </p>
+            <p className="mt-4">
+              Console, your agent, creates a UCAN delegating all capabilities on that space to your email DID.
+            </p>
+            <p className="mt-4">
+              You can allow others to use your space, by creating a delegation to their email or a specific agent from the share page.
+            </p>
+            <p className="mt-4">
+              For details on how this works see <a className='underline' href="https://github.com/web3-storage/specs/blob/main/w3-account.md">specs/w3-account</a>
+            </p>
+          </div>
+        </MaybePlanGate>
+      </AuthenticationEnsurer>
     </>
   )
 }

--- a/src/components/PlanGate.tsx
+++ b/src/components/PlanGate.tsx
@@ -32,18 +32,20 @@ export function PlanGate ({ children }: { children: ReactNode }): ReactNode {
 
   if (!plan?.product) {
     return (
-      <div className="flex flex-col justify-center items-center h-screen">
-        <div className="text-gray-200 text-center">
-          <h1 className="my-4 text-lg">Welcome {account}!</h1>
-          <p>
-            To get started with w3up you&apos;ll need to sign up for a subscription. If you choose
-            the free plan we won&apos;t charge your credit card, but we do need a card on file
-            before we will store your bits.
-          </p>
-          <p>
-            Pick a plan below and complete the Stripe signup flow to get started!
-          </p>
-          <StripePricingTable />
+      <div className="flex flex-col items-center h-screen">
+        <div className="text-white bg-gray-900/60 w-full rounded-md overflow-hidden">
+          <div className='px-10 py-4'>
+            <h1 className="my-4 text-lg">Welcome {account}!</h1>
+            <p className='max-w-xl mb-2'>
+              To get started with w3up you&apos;ll need to sign up for a subscription. If you choose
+              the free plan we won&apos;t charge your credit card, but we do need a card on file
+              before we will store your bits.
+            </p>
+            <p>
+              Pick a plan below and complete the Stripe checkout flow to get started!
+            </p>
+          </div>
+          <StripePricingTable className='rounded-md'/>
         </div>
       </div>
     )

--- a/src/components/SidebarLayout.tsx
+++ b/src/components/SidebarLayout.tsx
@@ -37,8 +37,12 @@ function Sidebar ({ sidebar = <div></div> }: SidebarComponentProps): JSX.Element
           <header className='opacity-0 lg:opacity-100'>
             <Logo className='py-8' />
           </header>
-          <H2 className='text-white'>Spaces</H2>
-          <SpaceFinder spaces={spaces} selected={space} setSelected={goToSpace} />
+          {spaces && (spaces.length > 0) && (
+            <>
+              <H2 className='text-white'>Spaces</H2>
+              <SpaceFinder spaces={spaces} selected={space} setSelected={goToSpace} />
+            </>
+          )}
         </div>
         {sidebar}
         <div className='flex flex-col items-center'>
@@ -63,58 +67,52 @@ export default function SidebarLayout ({ children }: LayoutComponentProps): JSX.
   return (
     <W3APIProvider uploadsListPageSize={20}>
       <Authenticator className='h-full' as='div'>
-        <AuthenticationEnsurer>
-          <SpaceEnsurer>
-            <MaybePlanGate>
-              <div className='flex min-h-full w-full text-white'>
-                {/* dialog sidebar for narrow browsers */}
-                <Transition.Root show={sidebarOpen} >
-                  <Dialog onClose={() => setSidebarOpen(false)} as='div' className='relative z-50'>
-                    <Transition.Child
-                      as={Fragment}
-                      enter="transition-opacity duration-200"
-                      enterFrom="opacity-0"
-                      enterTo="opacity-100"
-                      leave="transition-opacity duration-400"
-                      leaveFrom="opacity-100"
-                      leaveTo="opacity-0">
-                      <div className="fixed inset-0 bg-black/70" aria-hidden="true" />
-                    </Transition.Child>
-                    <div className="fixed inset-0 flex justify-left">
-                      <Transition.Child
-                        as={Fragment}
-                        enter="transition duration-200"
-                        enterFrom="-translate-x-full"
-                        enterTo="translate-x-0"
-                        leave="transition duration-400"
-                        leaveFrom="translate-x-0"
-                        leaveTo="-translate-x-full">
-                        <Dialog.Panel>
-                          <XMarkIcon className='text-white w-6 h-6 fixed top-2 -right-8' onClick={() => setSidebarOpen(false)} />
-                          <Sidebar />
-                        </Dialog.Panel>
-                      </Transition.Child>
-                    </div>
-                  </Dialog>
-                </Transition.Root>
-                {/* static sidebar for wide browsers */}
-                <div className='hidden lg:block'>
-                  <Sidebar />
-                </div>
-                <div className='w-full h-screen overflow-scroll text-white'>
-                  {/* top nav bar for narrow browsers, mainly to have a place to put the hamburger */}
-                  <div className='lg:hidden flex justify-between pt-4 px-4'>
-                    <Bars3Icon className='w-6 h-6' onClick={() => setSidebarOpen(true)} />
-                    <Logo className='w-full' />
-                  </div>
-                  <main className='grow text-black p-4'>
-                    {children}
-                  </main>
-                </div>
+        <div className='flex min-h-full w-full text-white'>
+          {/* dialog sidebar for narrow browsers */}
+          <Transition.Root show={sidebarOpen} >
+            <Dialog onClose={() => setSidebarOpen(false)} as='div' className='relative z-50'>
+              <Transition.Child
+                as={Fragment}
+                enter="transition-opacity duration-200"
+                enterFrom="opacity-0"
+                enterTo="opacity-100"
+                leave="transition-opacity duration-400"
+                leaveFrom="opacity-100"
+                leaveTo="opacity-0">
+                <div className="fixed inset-0 bg-black/70" aria-hidden="true" />
+              </Transition.Child>
+              <div className="fixed inset-0 flex justify-left">
+                <Transition.Child
+                  as={Fragment}
+                  enter="transition duration-200"
+                  enterFrom="-translate-x-full"
+                  enterTo="translate-x-0"
+                  leave="transition duration-400"
+                  leaveFrom="translate-x-0"
+                  leaveTo="-translate-x-full">
+                  <Dialog.Panel>
+                    <XMarkIcon className='text-white w-6 h-6 fixed top-2 -right-8' onClick={() => setSidebarOpen(false)} />
+                    <Sidebar />
+                  </Dialog.Panel>
+                </Transition.Child>
               </div>
-            </MaybePlanGate>
-          </SpaceEnsurer>
-        </AuthenticationEnsurer>
+            </Dialog>
+          </Transition.Root>
+          {/* static sidebar for wide browsers */}
+          <div className='hidden lg:block'>
+            <Sidebar />
+          </div>
+          <div className='w-full h-screen overflow-scroll text-white'>
+            {/* top nav bar for narrow browsers, mainly to have a place to put the hamburger */}
+            <div className='lg:hidden flex justify-between pt-4 px-4'>
+              <Bars3Icon className='w-6 h-6' onClick={() => setSidebarOpen(true)} />
+              <Logo className='w-full' />
+            </div>
+            <main className='grow text-black p-4'>
+              {children}
+            </main>
+          </div>
+        </div>
       </Authenticator>
     </W3APIProvider>
   )


### PR DESCRIPTION
Importing a space from someone else is a totally valid way to use the service, which means we can let users in to kick the tires before they have an account.

To enable this I moved the gates around, tweaked styling, and handled a couple UX cases where users might have seen empty space lists and such.

<img width="914" alt="Screenshot 2023-11-09 at 4 55 14 PM" src="https://github.com/web3-storage/console/assets/1113/174b0dcc-4523-4534-8310-3b47da12cc5a">

<img width="1211" alt="Screenshot 2023-11-09 at 4 55 21 PM" src="https://github.com/web3-storage/console/assets/1113/c0bc1b37-1f92-4703-b779-1d6e6aac6ca5">

<img width="647" alt="Screenshot 2023-11-09 at 4 54 34 PM" src="https://github.com/web3-storage/console/assets/1113/416047f1-73b9-47be-bc90-e3d25966d7de">

<img width="1342" alt="Screenshot 2023-11-09 at 4 54 13 PM" src="https://github.com/web3-storage/console/assets/1113/ffea3348-6a09-4999-9bf0-b63ddd8f4f87">


I think this is way nicer, but it could probably use a little of that @olizilla design sense.

There also seems to be something wrong with the space page if you go to a space you've imported - I'd like to land these design changes and then dig into that.