### PR TITLE
chore: update `.env.tpl` to sensible defaults for local dev

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -1,9 +1,9 @@
 # set these to your upload API service URL and the DID your service is using as its service DID
-NEXT_PUBLIC_W3UP_SERVICE_URL=https://up.web3.storage
-NEXT_PUBLIC_W3UP_SERVICE_DID=did:web:web3.storage
+NEXT_PUBLIC_W3UP_SERVICE_URL=https://staging.up.web3.storage
+NEXT_PUBLIC_W3UP_SERVICE_DID=did:web:staging.web3.storage
 
 # set these to values from Stripe settings
-NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID=prctbl_1NzhdvF6A5ufQX5vKNZuRhie
+NEXT_PUBLIC_STRIPE_PRICING_TABLE_ID=prctbl_1OCeiEF6A5ufQX5vPFlWRkPm
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_51LO87hF6A5ufQX5viNsPTbuErzfavdrEFoBuaJJPfoIhzQXdOUdefwL70YewaXA32ZrSRbK4U4fqebC7SVtyeNcz00qmgNgueC
 
 # set this to skip forcing users to pick a Stripe plan


### PR DESCRIPTION
I think developers should default to using staging, since with the addition of plan gating on the client and server they will otherwise need to enter real credit card information to do basic development. In staging they'll still need to go through the checkout flow, but can use fake credit card information (ie 4242 4242 4242 4242 and others listed at https://stripe.com/docs/testing?testing-method=card-numbers)

I've also updated to the "test mode" Stripe pricing table that redirects to localhost:3000 - the previously specified pricing table redirects to staging after checkout is complete