### PR TITLE
feat: extract usePlan and use it to chill our plan/get game

### DIFF
--- a/src/components/Authenticator.tsx
+++ b/src/components/Authenticator.tsx
@@ -5,7 +5,7 @@ import {
   useAuthenticator
 } from '@w3ui/react'
 import { Logo } from '../brand'
-import Loader from './Loader'
+import { TopLevelLoader } from './Loader'
 
 export function AuthenticationForm (): JSX.Element {
   const [{ submitted }] = useAuthenticator()
@@ -73,7 +73,7 @@ export function AuthenticationEnsurer ({
   if (client) {
     return <AuthenticationForm />
   }
-  return <Loader className='h-12 w-full mt-12' />
+  return <TopLevelLoader />
 }
 
 

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -5,3 +5,5 @@ export default function DefaultLoader({ className = '' }: { className?: string }
     <ArrowPathIcon className={`animate-spin ${className}`} />
   )
 }
+
+export const TopLevelLoader = () => <DefaultLoader className='h-12 w-full mt-12 text-white' />

--- a/src/components/PlanGate.tsx
+++ b/src/components/PlanGate.tsx
@@ -1,38 +1,18 @@
 'use client'
 
-import { ReactNode, useEffect, useState } from 'react'
-import { useW3, PlanGetSuccess } from '@w3ui/react'
+import { ReactNode, useState } from 'react'
+import { useW3 } from '@w3ui/react'
 import StripePricingTable from './PricingTable';
-import DefaultLoader from './Loader';
+import { TopLevelLoader } from './Loader';
 import { Web3StorageLogo } from '@/brand';
+import { usePlan } from '@/hooks';
 
 export function PlanGate ({ children }: { children: ReactNode }): ReactNode {
   const [error, setError] = useState<any>()
   const [{ accounts }] = useW3()
-  const [plan, setPlan] = useState<PlanGetSuccess>()
-  useEffect(function () {
-    (async function () {
-      if (accounts.length) {
-        try {
-          // TODO: account selection
-          const account = accounts[0]
-          const result = await account.plan.get()
-          if (result.ok) {
-            setPlan(result.ok)
-          } else {
-            setError(result.error)
-          }
-        } catch (err) {
-          console.error("CAUGHT ERROR", err)
-          setError(err)
-        }
-      } else {
-        setPlan(undefined)
-      }
-    })()
-  }, [accounts])
+  const { data: plan } = usePlan(accounts[0])
   if (!plan && !error) {
-    return <DefaultLoader className='w-12 h-12 text-white' />
+    return <TopLevelLoader />
   }
 
   if (!plan?.product) {

--- a/src/components/UsageBar.tsx
+++ b/src/components/UsageBar.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import { ReactNode } from 'react'
-import { useW3, PlanGetSuccess, SpaceDID } from '@w3ui/react'
+import { useW3, SpaceDID } from '@w3ui/react'
 import useSWR from 'swr'
 import { GB, TB, filesize } from '@/lib'
+import { usePlan } from '@/hooks'
 
 const BarHeight = 10
 
@@ -18,17 +19,9 @@ export function UsageBar (): ReactNode {
   // TODO: introduce account switcher
   const account = accounts[0]
 
-  const { data: plan } = useSWR<PlanGetSuccess|undefined>(`/plan/${account?.did() ?? ''}`, {
-    fetcher: async () => {
-      if (!account) return
-      const result = await account.plan.get()
-      if (result.error) throw new Error('getting plan', { cause: result.error })
-      return result.ok
-    },
-    onError: err => console.error(err.message, err.cause)
-  })
+  const { data: plan } = usePlan(account)
 
-  const { data: usage } = useSWR<Record<SpaceDID, number>|undefined>(`/usage/${account ?? ''}`, {
+  const { data: usage } = useSWR<Record<SpaceDID, number> | undefined>(`/usage/${account ?? ''}`, {
     fetcher: async () => {
       const usage: Record<SpaceDID, number> = {}
       if (!account || !client) return
@@ -59,7 +52,7 @@ export function UsageBar (): ReactNode {
     },
     onError: err => console.error(err.message, err.cause)
   })
-  
+
   const allocated = Object.values(usage ?? {}).reduce((total, n) => total + n, 0)
   const limit = plan?.product ? Plans[plan.product]?.limit : null
 
@@ -77,7 +70,7 @@ export function UsageBar (): ReactNode {
               return (
                 <div
                   key={space}
-                  style={{ width: `${total/limit * 100}%`, height: BarHeight }}
+                  style={{ width: `${total / limit * 100}%`, height: BarHeight }}
                   className='bg-white/80 hover:bg-white bg-clip-padding inline-block border-r last:border-r-0 border-transparent'
                   title={`${space}: ${filesize(total)}`}
                 />
@@ -94,7 +87,7 @@ export function UsageBar (): ReactNode {
   )
 }
 
-const startOfMonth = (now: string|number|Date) => {
+const startOfMonth = (now: string | number | Date) => {
   const d = new Date(now)
   d.setUTCDate(1)
   d.setUTCHours(0)
@@ -104,7 +97,7 @@ const startOfMonth = (now: string|number|Date) => {
   return d
 }
 
-const startOfLastMonth = (now: string|number|Date) => {
+const startOfLastMonth = (now: string | number | Date) => {
   const d = startOfMonth(now)
   d.setUTCMonth(d.getUTCMonth() - 1)
   return d

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -1,0 +1,13 @@
+import { Account, PlanGetSuccess } from '@w3ui/react'
+import useSWR from 'swr'
+
+export const usePlan = (account: Account) =>
+  useSWR<PlanGetSuccess | undefined>(`/plan/${account?.did() ?? ''}`, {
+    fetcher: async () => {
+      if (!account) return
+      const result = await account.plan.get()
+      if (result.error) throw new Error('getting plan', { cause: result.error })
+      return result.ok
+    },
+    onError: err => console.error(err.message, err.cause)
+  })


### PR DESCRIPTION
We fetch `plan/get` wayyy too much and it leads to janky loaders when navigating between sections that use different instances of the same layout component, like the space list and the import/create tabs.

Using SWR fixes this by utilizing the "stale while revalidate" pattern to served a cached version of the `plan/get` result in all cases - no more weird loader jitters!

Also DRY up the top level loaders so they don't flash black-and-centered and then white-and-left-justified.