### PR TITLE
fix: get plan gate working again

### DIFF
--- a/src/components/PlanGate.tsx
+++ b/src/components/PlanGate.tsx
@@ -8,9 +8,8 @@ import { Web3StorageLogo } from '@/brand';
 import { usePlan } from '@/hooks';
 
 export function PlanGate ({ children }: { children: ReactNode }): ReactNode {
-  const [error, setError] = useState<any>()
   const [{ accounts }] = useW3()
-  const { data: plan } = usePlan(accounts[0])
+  const { data: plan, error } = usePlan(accounts[0])
   if (!plan && !error) {
     return <TopLevelLoader />
   }
@@ -43,7 +42,8 @@ export function PlanGate ({ children }: { children: ReactNode }): ReactNode {
 }
 
 export function MaybePlanGate ({ children }: { children: ReactNode }): ReactNode {
-  if (process.env.NEXT_PUBLIC_DISABLE_PLAN_GATE == 'true') {
+  console.log("MEBBE")
+  if (false) {
     return children
   } else {
     return <PlanGate>{children}</PlanGate>

--- a/src/components/SidebarLayout.tsx
+++ b/src/components/SidebarLayout.tsx
@@ -67,12 +67,11 @@ interface LayoutComponentProps extends SidebarComponentProps {
 
 export default function SidebarLayout ({ children }: LayoutComponentProps): JSX.Element {
   const [sidebarOpen, setSidebarOpen] = useState(false)
-
   return (
     <Authenticator className='h-full' as='div'>
       <AuthenticationEnsurer>
-        <SpaceEnsurer>
-          <MaybePlanGate>
+        <MaybePlanGate>
+          <SpaceEnsurer>
             <div className='flex min-h-full w-full text-white'>
               {/* dialog sidebar for narrow browsers */}
               <Transition.Root show={sidebarOpen} >
@@ -119,8 +118,8 @@ export default function SidebarLayout ({ children }: LayoutComponentProps): JSX.
                 </main>
               </div>
             </div>
-          </MaybePlanGate>
-        </SpaceEnsurer>
+          </SpaceEnsurer>
+        </MaybePlanGate>
       </AuthenticationEnsurer>
     </Authenticator>
   )


### PR DESCRIPTION
I'm pretty sure signup has been broken since I started using `usePlan` in the PlanGate - I was using the wrong error AND it looks like the SpaceEnsurer was outside the PlanGate when it should have been inside it (since you can't create a space until you have a plan)

Unfortunately this is pretty hard to test automatically, but I've tested in my local env and will test in staging before pushing to prod