### PR TITLE
fix: delegate space recovery after creation

### DIFF
--- a/src/components/SpaceCreator.tsx
+++ b/src/components/SpaceCreator.tsx
@@ -54,8 +54,17 @@ export function SpaceCreatorForm ({
       const provider = (process.env.NEXT_PUBLIC_W3UP_PROVIDER || 'did:web:web3.storage') as DID<'web'>
       await account.provision(space.did(), { provider })
 
-      await space.createRecovery(account.did())
+      // MUST do this before creating recovery, as it creates necessary authorizations
       await space.save()
+
+      // TODO this should have its own UX, like the CLI does, which would allow us to handle errors
+      const recovery = await space.createRecovery(account.did())
+
+      // TODO we are currently ignoring the result of this because we have no good way to handle errors - revamp this ASAP!
+      await client.capability.access.delegate({
+        space: space.did(),
+        delegations: [recovery],
+      })
 
       setSpace(client.spaces().find(s => s.did() === space.did()))
       setCreated(true)


### PR DESCRIPTION
We were not doing this, and as a result any spaces created in the web console recently will not be recoverable.

I'd like to get this bugfix into production ASAP but have left TODOs for follow-on work that should be completed as soon as possible.

We should also give users the ability to see if their space is recoverable from the service. I'll create issues for all of this.