### PR TITLE
feat: add a toaster for notifications and other snacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "next": "^13.5.4",
     "react": "latest",
     "react-dom": "latest",
+    "react-hot-toast": "^2.4.1",
     "swr": "^2.2.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ dependencies:
   react-dom:
     specifier: latest
     version: 18.2.0(react@18.2.0)
+  react-hot-toast:
+    specifier: ^2.4.1
+    version: 2.4.1(csstype@3.1.3)(react-dom@18.2.0)(react@18.2.0)
   swr:
     specifier: ^2.2.4
     version: 2.2.4(react@18.2.0)
@@ -3499,6 +3502,14 @@ packages:
       slash: 3.0.0
     dev: true
 
+  /goober@2.1.14(csstype@3.1.3):
+    resolution: {integrity: sha512-4UpC0NdGyAFqLNPnhCT2iHpza2q+RAY3GV85a/mRPdzyPQMsj0KmMMuetdIkzWRbJ+Hgau1EZztq8ImmiMGhsg==}
+    peerDependencies:
+      csstype: ^3.0.10
+    dependencies:
+      csstype: 3.1.3
+    dev: false
+
   /gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
     dependencies:
@@ -4787,6 +4798,20 @@ packages:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.0
+    dev: false
+
+  /react-hot-toast@2.4.1(csstype@3.1.3)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
+    dependencies:
+      goober: 2.1.14(csstype@3.1.3)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - csstype
     dev: false
 
   /react-is@16.13.1:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css'
 import type { Metadata } from 'next'
 import Provider from '@/components/W3UIProvider'
+import Toaster from '@/components/Toaster'
 
 export const metadata: Metadata = {
   title: 'w3up console',
@@ -18,6 +19,7 @@ export default function RootLayout ({
         <Provider>
           <>{children}</>
         </Provider>
+        <Toaster />
       </body>
     </html>
   )

--- a/src/app/plans/change/page.tsx
+++ b/src/app/plans/change/page.tsx
@@ -6,6 +6,7 @@ import { CheckCircleIcon } from '@heroicons/react/24/outline'
 import DefaultLoader from "@/components/Loader"
 import { useState } from "react"
 import SidebarLayout from "@/components/SidebarLayout"
+import { ucantoast } from "@/toaster"
 
 interface PlanSectionProps {
   planID: DID
@@ -38,7 +39,11 @@ function PlanSection ({ planID, planName, flatFee, flatFeeAllotment, perGbFee }:
   async function selectPlan (selectedPlanID: DID) {
     try {
       setIsUpdatingPlan(true)
-      await setPlan(selectedPlanID)
+      await ucantoast(setPlan(selectedPlanID), {
+        loading: "Updating plan...",
+        success: "Plan updated!",
+        error: "Failed to update plan, check the console for more details."
+      })
     } finally {
       setIsUpdatingPlan(false)
     }

--- a/src/components/Toaster.tsx
+++ b/src/components/Toaster.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { Toaster, ToastIcon, resolveValue } from "react-hot-toast"
+import { Transition } from "@headlessui/react"
+
+export default function TailwindToaster () {
+  return (
+    <Toaster position="top-right">
+      {(t) => (
+        <Transition
+          appear
+          show={t.visible}
+          className="transform p-4 flex bg-white rounded shadow-lg"
+          enter="transition-all duration-150"
+          enterFrom="opacity-0 scale-50"
+          enterTo="opacity-100 scale-100"
+          leave="transition-all duration-150"
+          leaveFrom="opacity-100 scale-100"
+          leaveTo="opacity-0 scale-75"
+        >
+          <ToastIcon toast={t} />
+          <p className="px-2">{resolveValue(t.message, t)}</p>
+        </Transition>
+      )}
+    </Toaster>
+  )
+}

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -11,7 +11,6 @@ type UsePlanResult = SWRResponse<PlanGetSuccess | undefined> & {
 }
 
 export const usePlan = (account: Account) => {
-  const { mutate } = useSWRConfig()
   const result = useSWR<PlanGetSuccess | undefined>(planKey(account), {
     fetcher: async () => {
       if (!account) return
@@ -25,8 +24,9 @@ export const usePlan = (account: Account) => {
   // to avoid calling the getters in SWRResponse when copying values over -
   // I can't think of a cleaner way to do this but open to refactoring
   result.setPlan = async (plan: DID) => {
-    await account.plan.set(plan)
+    const setResult = await account.plan.set(plan)
     await result.mutate()
+    return setResult
   }
   return result as UsePlanResult
 }

--- a/src/toaster.ts
+++ b/src/toaster.ts
@@ -1,0 +1,20 @@
+import { Result } from '@ucanto/interface'
+import { toast } from 'react-hot-toast'
+
+export const ucantoast = async (promise: Promise<Result>, options: any) => {
+  return toast.promise(new Promise(async (resolve, reject) => {
+    promise.then((result) => {
+      if (result.ok) {
+        resolve(result.ok)
+      } else {
+        console.error("toaster got a Ucanto error: ", result.error)
+        resolve(result.error)
+      }
+    })
+
+    promise.catch((err: unknown) => {
+      console.error("toaster caught an error: ", err)
+      reject(err)
+    })
+  }), options)
+}

--- a/src/toaster.ts
+++ b/src/toaster.ts
@@ -2,19 +2,12 @@ import { Result } from '@ucanto/interface'
 import { toast } from 'react-hot-toast'
 
 export const ucantoast = async (promise: Promise<Result>, options: any) => {
-  return toast.promise(new Promise(async (resolve, reject) => {
-    promise.then((result) => {
-      if (result.ok) {
-        resolve(result.ok)
-      } else {
-        console.error("toaster got a Ucanto error: ", result.error)
-        resolve(result.error)
-      }
-    })
-
-    promise.catch((err: unknown) => {
-      console.error("toaster caught an error: ", err)
-      reject(err)
-    })
-  }), options)
+  return toast.promise((async () => {
+    const result = await promise
+    if (result.ok) {
+      return result.ok
+    } else {
+      throw result.error
+    }
+  })(), options)
 }


### PR DESCRIPTION
Use `react-hot-toast` to introduce "toaster" style notifications:

https://react-hot-toast.com/

These should be refined over time, but as an experiment I've introduced this on the "plan change" page and am using it to let the user know when something goes wrong:


https://github.com/web3-storage/console/assets/1113/ffe3c1cf-5a42-4471-920c-649bfecb36a4

or when something goes right:


https://github.com/web3-storage/console/assets/1113/af7f5bd2-cf20-482c-803c-22d5804ed86a

If this seems like a good pattern to everyone I think we should start using it more broadly - no longer will our users be forced to watch a whole file upload just to get feedback about its success or failure!

